### PR TITLE
Remove po from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 issues.txt
 .bzr
 doc/.build
-po
 .tx
 *~
 *pyc


### PR DESCRIPTION
The po directory is stored in Git, so it makes little sense to ignore it. It makes impossible to add new files to Git in this repository.